### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dev-shimada/dcstop/security/code-scanning/1](https://github.com/dev-shimada/dcstop/security/code-scanning/1)

In general, the problem is fixed by explicitly declaring a `permissions` block at the workflow root (or job level) to restrict the `GITHUB_TOKEN` to the minimum required scope. If the workflow doesn’t need to write to the repository or interact with issues/PRs, `contents: read` is sufficient.

For this specific workflow, the `ci` job uses `actions/checkout`, `actions/setup-go`, linting, vet, tests, and `goveralls` with `COVERALLS_TOKEN` from `secrets.GITHUB_TOKEN`. None of these steps require write access to repository contents or to PRs/issues. Therefore, we can safely set `permissions: contents: read` for the entire workflow. The cleanest approach is to add a root-level `permissions` block right under the `name: CI` line so it applies to all jobs that don’t override it. No other code or steps need to change.

Concretely:
- Edit `.github/workflows/CI.yaml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  immediately after `name: CI` (line 1).
- Leave all other lines unchanged.

No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
